### PR TITLE
fix: await body write and write body before headers in saveResponse

### DIFF
--- a/src/CacheRouteHandler/index.ts
+++ b/src/CacheRouteHandler/index.ts
@@ -103,8 +103,8 @@ export class CacheRouteHandler {
     // file can be updated by another worker
     if (!this.isUpdated()) {
       debug(`Writing cache: ${this.cacheDir}`);
+      await new BodyFile(this.cacheDir, responseInfo).save(body);
       new HeadersFile(this.cacheDir).save(responseInfo);
-      new BodyFile(this.cacheDir, responseInfo).save(body);
     } else {
       debug(`Skip writing cache, updated by another worker: ${this.cacheDir}`);
     }


### PR DESCRIPTION
## Problem

Concurrent Playwright workers sharing the same `baseDir` can fail with `ENOENT: no such file or directory, open '<cacheDir>/body.<ext>'` on a fresh cache.

`CacheRouteHandler.saveResponse` writes `headers.json` synchronously, then calls `new BodyFile(...).save(body)` **without awaiting** the returned promise:

```ts
new HeadersFile(this.cacheDir).save(responseInfo);    // sync writeFileSync
new BodyFile(this.cacheDir, responseInfo).save(body); // async, not awaited
```

A concurrent worker that arrives after the sync `headers.json` write but before the async body write completes:

1. `storeLastModified()` reads the just-written `mtime` of `headers.json` (> 0).
2. `isExpired()` returns `false` (within TTL).
3. `useRealRequest = false`, the handler enters `fetchFromCache()`.
4. `BodyFile.read()` runs `fs.promises.readFile('<cacheDir>/body.<ext>')` → **ENOENT**, the body file is not on disk yet.

We hit this in CI with 5 parallel Playwright workers and a gitignored cache directory (fresh on every run).

## Minimal repro

Pure-Node script, no Playwright needed — mirrors the order of operations in `saveResponse` / `fetchFromCache`:

```js
const fs = require('node:fs');
const path = require('node:path');
const os = require('node:os');

const root = fs.mkdtempSync(path.join(os.tmpdir(), 'race-'));

class HeadersFile {
  constructor(dir) { this.path = path.join(dir, 'headers.json'); }
  save(info) {
    fs.mkdirSync(path.dirname(this.path), { recursive: true });
    fs.writeFileSync(this.path, JSON.stringify(info));
  }
}
class BodyFile {
  constructor(dir) { this.path = path.join(dir, 'body.woff2'); }
  async save(buf) {
    await fs.promises.mkdir(path.dirname(this.path), { recursive: true });
    await fs.promises.writeFile(this.path, buf);
  }
  async read() { return fs.promises.readFile(this.path); }
}

// Mirrors CacheRouteHandler.saveResponse on main:
async function saveResponse(dir, body) {
  new HeadersFile(dir).save({ headers: { 'content-type': 'font/woff2' } });
  new BodyFile(dir).save(body); // <- not awaited
}

// Mirrors CacheRouteHandler.fetchFromCache:
async function fetchFromCache(dir) {
  return new BodyFile(dir).read();
}

(async () => {
  const dir = path.join(root, 'subdir');
  const body = Buffer.alloc(50 * 1024, 7);

  await saveResponse(dir, body);
  try {
    const data = await fetchFromCache(dir);
    console.log('OK', data.length);
  } catch (e) {
    console.log('FAIL', e.code); // ENOENT
  }

  fs.rmSync(root, { recursive: true, force: true });
})();
```

Output:

```
FAIL ENOENT
```

## Fix

Two changes in `saveResponse`:

1. `await` the body write so `saveResponse` does not return until the body is flushed to disk.
2. Write the body **before** `headers.json`, so the file other workers use as the cache-hit signal (`headers.json` mtime, see `storeLastModified` / `isUpdated`) only becomes visible after the body file is already on disk.

```diff
       debug(`Writing cache: ${this.cacheDir}`);
+      await new BodyFile(this.cacheDir, responseInfo).save(body);
       new HeadersFile(this.cacheDir).save(responseInfo);
-      new BodyFile(this.cacheDir, responseInfo).save(body);
```

## Notes

- The `isUpdated()` short-circuit still protects against double-writes when two workers race on the same key.
- Reproduced on `0.2.2`. The relevant code path is unchanged on `main`.
- This patch closes the fatal ENOENT race only. Other narrower races remain (read-during-write of `headers.json` / `body.<ext>`, TOCTOU in `isUpdated`). Fully closing them needs atomic publish via temp-file + `rename`, which I'd suggest as a separate change to keep this PR minimal.
